### PR TITLE
Only extract xcframeworks if a target links against Carthage frameworks

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -173,6 +173,12 @@ public struct BuildSettings {
 		return productType.fanout(machOType).map(FrameworkType.init)
 	}
 
+	internal var frameworkSearchPaths: Result<[URL], CarthageError> {
+		return self["FRAMEWORK_SEARCH_PATHS"].map { paths in
+			paths.split(separator: " ").map { URL(fileURLWithPath: String($0), isDirectory: true) }
+		}
+	}
+
 	/// Attempts to determine the URL to the built products directory.
 	public var builtProductsDirectoryURL: Result<URL, CarthageError> {
 		return self["BUILT_PRODUCTS_DIR"].map { productsDir in


### PR DESCRIPTION
This should handle an edge case @jdhealy noticed: If a checked out project
doesn't link against other frameworks in Carthage/Build, then adding the
extracted frameworks tempdir to its FRAMEWORK_SEARCH_PATHS can influence
compilation.

By only extracting when the target is already configured to link
frameworks from a Carthage/Build directory, we can ensure that targets
with no Carthage dependencies build in the same environment.